### PR TITLE
BUGFIX: Handle multiline YAML front matter correctly

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+- BUGFIX: Handle mutliline YAML Frontmatter correctly
+
 1.000000 2017-07-13
 
 - Intial Release

--- a/lib/Code/TidyAll/Plugin/YAMLFrontMatter.pm
+++ b/lib/Code/TidyAll/Plugin/YAMLFrontMatter.pm
@@ -19,6 +19,12 @@ extends 'Code::TidyAll::Plugin';
 #     \A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)    (with the m flag)
 # from the Jekyll source code here:
 # https://github.com/jekyll/jekyll/blob/c7d98cae2652b2df7ebd3c60b4f8c87950760e47/lib/jekyll/document.rb#L13
+# note - The 'm' modifier in ruby is essentially the same as 's' in Perl
+#        so we need to enable the 's' modifier not 'm'
+#      - Ruby essentially always treats '^' and '$' the way Perl does when the
+#        'm' modifier is enabled, so we need to turn that on too
+#      - We need to enable the 'x' modifier and space things out so that
+#        Perl treats '$\n' as '$' and '\n' and not the variable '$\' and 'n'
 my $YAML_REGEX = qr{
    \A
       # the starting ---, and anything up until...
@@ -26,7 +32,7 @@ my $YAML_REGEX = qr{
 
       # ...the first --- or ... on their own line
       ^ (?:---|\.\.\.) \s* $ \n?
-}mx;
+}msx;
 
 has encoding => (
     is => 'ro',

--- a/t/lib/Test/Code/TidyAll/Plugin/YAMLFrontMatter.pm
+++ b/t/lib/Test/Code/TidyAll/Plugin/YAMLFrontMatter.pm
@@ -58,6 +58,16 @@ sub test_main : Tests {
     );
 
     $self->tidyall(
+        source => "---\none: line\n---\nThis should work",
+        desc   => 'one line is okay'
+    );
+
+    $self->tidyall(
+        source => "---\none: line\ntwo: lines\n---\nThis should work",
+        desc   => 'two lines are okay'
+    );
+
+    $self->tidyall(
         source => 'fish',
         expect_error =>
             qr/dummy[.]md' does not start with valid YAML Front Matter/,


### PR DESCRIPTION
When porting the regexp over from the ruby source code I made some mistakes with respect to the modifier flags having different meanings, and somehow failed to test multi-line YAML front matter works properly.

  - Add breaking tests
  - Fix breaking tests
  - Document the change in the regexp modifiers in comments# Please enter the commit message for your changes. Lines starting